### PR TITLE
Add dataset download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ This paper introduces MCTrack, a new 3D multi-object tracking method that achiev
     ```
     $ python preprocess/convert2baseversion.py --dataset kitti/nuscenes/waymo
     ```
+
+- Alternatively, you can download our prepared BaseVersion data automatically:
+```bash
+$ python scripts/download_baseversion.py
+```
 - Eventually, you will get the data format of baseversion in the path `data/base_version/`.
     ```
     data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow==10.4.0
 nuscenes-devkit==1.1.11
 torch
 networkx
+gdown

--- a/scripts/download_baseversion.py
+++ b/scripts/download_baseversion.py
@@ -1,0 +1,19 @@
+import os
+import subprocess
+
+URL = "https://drive.google.com/drive/folders/15QDnPR9t3FO18fVzCyqUu4h-7COl9Utd?usp=sharing"
+DEST = os.path.join("data", "base_version")
+
+
+def main():
+    os.makedirs(DEST, exist_ok=True)
+    cmd = ["gdown", "--folder", URL, "-O", DEST]
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        print("Failed to download dataset. Please check your network connection and gdown installation.")
+        raise e
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/download_baseversion.py` to fetch prepared datasets from Google Drive
- update README to document dataset download script
- add `gdown` to requirements

## Testing
- `python -m py_compile scripts/download_baseversion.py`
- `python scripts/download_baseversion.py --help` *(fails: FileNotFoundError: gdown)*